### PR TITLE
Change how URLs are generated.

### DIFF
--- a/PerpetuumSoft.Knockout/KnockoutContext.cs
+++ b/PerpetuumSoft.Knockout/KnockoutContext.cs
@@ -238,11 +238,9 @@ namespace PerpetuumSoft.Knockout
       return new MvcHtmlString(exec);
     }
 
-    protected static UrlHelper Url()
+    protected UrlHelper Url()
     {
-      var httpContext = new HttpContextWrapper(HttpContext.Current);
-      var requestContext = new RequestContext(httpContext, new RouteData());
-      return new UrlHelper(requestContext);
+      return new UrlHelper(viewContext.RequestContext);
     }
   }
 }


### PR DESCRIPTION
On a project I'm working on, the current cude for Url() in KnockoutContext wasn't getting route data. Since KnockoutContext has a ViewContext, we can get the RequestContext
from that to make a UrlHelper, instead of jumping through hoops. This is both cleaner, and works correctly.
