### PR TITLE
Update KnockoutUtilities.cs

### DIFF
--- a/PerpetuumSoft.Knockout/Utilities/KnockoutUtilities.cs
+++ b/PerpetuumSoft.Knockout/Utilities/KnockoutUtilities.cs
@@ -20,8 +20,13 @@ namespace PerpetuumSoft.Knockout
     {
       if (data == null)
         return;
-      foreach (var property in data.GetType().GetProperties())
+      var type = data.GetType();
+      if (type.IsClass && type.Namespace.Equals("System.Data.Entity.DynamicProxies"))
+          type = type.BaseType;
+      foreach (var property in type.GetProperties())
       {
+        if (property.GetCustomAttributes(typeof(Newtonsoft.Json.JsonIgnoreAttribute), false).Length > 0)
+          continue;
         if (property.GetGetMethod() == null)
           continue;
         if (property.GetGetMethod().GetParameters().Length > 0)
@@ -31,7 +36,7 @@ namespace PerpetuumSoft.Knockout
         {
           value = GetActualValue(property.PropertyType, null);
           if (value != null)
-            property.SetValue(data, GetActualValue(property.PropertyType, null), null);
+            property.SetValue(data, value, null);
         }
         else if (!IsSystemType(property.PropertyType))
           ConvertData(value);


### PR DESCRIPTION
Add JsonIgnore attribute validation to avoid reflection over objects that will not be serialized by json.net
Fixes for ensure JsonIgnore attribute validation works with entity framework proxies.
