### PR TITLE
added type="text" to textbox

### DIFF
--- a/PerpetuumSoft.Knockout/Html/KnockoutHtml.cs
+++ b/PerpetuumSoft.Knockout/Html/KnockoutHtml.cs
@@ -32,7 +32,7 @@ namespace PerpetuumSoft.Knockout
 
     public KnockoutTagBuilder<TModel> TextBox(Expression<Func<TModel, object>> text, object htmlAttributes = null)
     {
-      return Input(text, null, htmlAttributes);
+      return Input(text, "text", htmlAttributes);
     }
 
     public KnockoutTagBuilder<TModel> Password(Expression<Func<TModel, object>> text, object htmlAttributes = null)


### PR DESCRIPTION
There are problems with styling, when TextBoxes don't have the type="text" and I don't see any reason, why they should not have it.

The workaround is to provide type="text" in htmlAttributes, but it is more appropriate to have it built-in.
