### PR TITLE
Fixed bug: trying to set read-only property

### DIFF
--- a/PerpetuumSoft.Knockout/Utilities/KnockoutUtilities.cs
+++ b/PerpetuumSoft.Knockout/Utilities/KnockoutUtilities.cs
@@ -35,7 +35,7 @@ namespace PerpetuumSoft.Knockout
         if (value == null)
         {
           value = GetActualValue(property.PropertyType, null);
-          if (value != null)
+          if (value != null && property.CanWrite)
             property.SetValue(data, value, null);
         }
         else if (!IsSystemType(property.PropertyType))


### PR DESCRIPTION
This doesn't throw an exception on .NET 4.0, but on .NET 4.5 it does.
