### PR TITLE
add KnockoutBinding.Custom(string, Expression) overload

### DIFF
--- a/PerpetuumSoft.Knockout/Binding/KnockoutBinding.cs
+++ b/PerpetuumSoft.Knockout/Binding/KnockoutBinding.cs
@@ -175,6 +175,12 @@ namespace PerpetuumSoft.Knockout
       return this;
     }
 
+    public KnockoutBinding<TModel> Custom(string name, Expression<Func<TModel, object>> binding)
+    {
+        Items.Add(new KnockoutBindingItem<TModel, object> { Name = name, Expression = binding });
+        return this;
+    }
+
     // *** Common ***
 
     private readonly List<KnockoutBindingItem> items = new List<KnockoutBindingItem>();


### PR DESCRIPTION
Added KnockoutBinding.Custom(string, Expression) overload, so it can be used like this:

@ko.Bind.Custom("customBinding", m => m.Property)
