### PR TITLE
Adds 'input' to valueUpdate binding options

### DIFF
--- a/PerpetuumSoft.Knockout.Tests/KnockoutExpressionConverterTest.cs
+++ b/PerpetuumSoft.Knockout.Tests/KnockoutExpressionConverterTest.cs
@@ -183,5 +183,16 @@ namespace PerpetuumSoft.Knockout.Tests
         AssertStringEquivalent("text:(parseInt($data)+parseInt(1))", bind);
       }
     }
+
+    // valueUpdate: 'input'
+    [TestMethod]
+    public void ValueUpdateInput()
+    {
+        var viewContext = new ViewContext { Writer = new StringWriter() };
+        var context = new KnockoutContext<TestModel>(viewContext);
+        var binding = new KnockoutBinding<TestModel>(context);
+        string bind = context.Bind.Text(m => m.A).ValueUpdate(KnockoutValueUpdateKind.Input).BindingAttributeContent();
+        AssertStringEquivalent("text : A,valueUpdate : 'input'", bind);
+    }
   }
 }

--- a/PerpetuumSoft.Knockout/Binding/KnockoutBindingEnums.cs
+++ b/PerpetuumSoft.Knockout/Binding/KnockoutBindingEnums.cs
@@ -2,6 +2,6 @@
 {
   public enum KnockoutValueUpdateKind
   {
-    Change, KeyUp, KeyPress, AfterKeyDown
+    Change, KeyUp, KeyPress, AfterKeyDown, Input
   }
 }


### PR DESCRIPTION
Knockout.js value binding allows valueUpdate: 'input', so I added it to KnockoutValueUpdateKind enum and also added a test case for it.
