### PR TITLE
Bug fix: stack overflow issue

### DIFF
--- a/PerpetuumSoft.Knockout.Tests/KnockoutUtilitiesTest.cs
+++ b/PerpetuumSoft.Knockout.Tests/KnockoutUtilitiesTest.cs
@@ -1,0 +1,24 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PerpetuumSoft.Knockout.Tests
+{
+    [TestClass]
+    public class KnockoutUtilitiesTest
+    {
+        [TestMethod]
+        public void ConvertDataTest01()
+        {
+            TestModel model = new TestModel();
+            bool doesNotCauseStackOverflow = false;
+
+            Knockout.KnockoutUtilities.ConvertData(model);
+            
+            doesNotCauseStackOverflow = true;
+            Assert.IsTrue(doesNotCauseStackOverflow);
+        }
+    }
+}

--- a/PerpetuumSoft.Knockout.Tests/PerpetuumSoft.Knockout.Tests.csproj
+++ b/PerpetuumSoft.Knockout.Tests/PerpetuumSoft.Knockout.Tests.csproj
@@ -67,6 +67,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="KnockoutExpressionConverterTest.cs" />
+    <Compile Include="KnockoutUtilitiesTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TestModel.cs" />
   </ItemGroup>

--- a/PerpetuumSoft.Knockout.Tests/TestModel.cs
+++ b/PerpetuumSoft.Knockout.Tests/TestModel.cs
@@ -21,6 +21,8 @@ namespace PerpetuumSoft.Knockout.Tests
 
         public TestModel SubModel { get; set; }
 
+        public static TestModel StaticReferenceModel { get { return new TestModel(); } }
+
         [ScriptIgnore]
         public Expression<Func<string>> Concatenation
         {

--- a/PerpetuumSoft.Knockout/Utilities/KnockoutUtilities.cs
+++ b/PerpetuumSoft.Knockout/Utilities/KnockoutUtilities.cs
@@ -27,6 +27,8 @@ namespace PerpetuumSoft.Knockout
                 type = type.BaseType;
             foreach (var property in type.GetProperties())
             {
+                if (property.GetGetMethod().IsStatic && property.PropertyType == property.DeclaringType)
+                    continue;
                 if (property.GetCustomAttributes(typeof(Newtonsoft.Json.JsonIgnoreAttribute), false).Length > 0)
                     continue;
                 if (property.GetGetMethod() == null)


### PR DESCRIPTION
This fixes a bug where, given a type that contains a static property of its own type with a non-null value, the ConvertData function will cause a stack overflow when called on an object of that type. This case can arise in structs that contain references to global values, such as System.Guid.Empty (the System.Guid type does not cause this crash because it is excluded by the IsSystemType() function).
